### PR TITLE
feat(community-portal): Add data layer for contests feature

### DIFF
--- a/a2sv_community_portal_mobile/lib/features/contest/data/datasources/contest_remote_datasource.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/data/datasources/contest_remote_datasource.dart
@@ -1,0 +1,35 @@
+import 'dart:convert';
+
+import 'package:a2sv_community_portal_mobile/core/errors/exceptions.dart';
+import 'package:a2sv_community_portal_mobile/core/utils/constants.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/data/model/contest.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/domain/entities/contest.dart';
+import 'package:http/http.dart' as http;
+
+abstract class ContestRemoteDataSource {
+  Future<List<Contest>> getContests();
+}
+
+class ContestRemoteDataSourceImpl implements ContestRemoteDataSource {
+  final http.Client client;
+  String uri = "https://api";
+
+  ContestRemoteDataSourceImpl(this.client);
+
+  @override
+  Future<List<Contest>> getContests() async {
+    final response = await client.get(
+      Uri.parse(uri),
+      headers: {'Content-Type': 'application/json'},
+    );
+    if (response.statusCode == 200) {
+      final jsonContests = json.decode(response.body) as List<dynamic>;
+      return jsonContests
+          .map((jsonContest) => ContestModel.fromJson(jsonContest) as Contest)
+          .toList();
+    } else {
+      throw ServerException(serverFaliure);
+    }
+  }
+}
+

--- a/a2sv_community_portal_mobile/lib/features/contest/data/model/contest.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/data/model/contest.dart
@@ -1,0 +1,36 @@
+import 'package:equatable/equatable.dart';
+
+class ContestModel extends Equatable {
+  final String title;
+  final String description;
+  final DateTime date;
+  final String link;
+
+  const ContestModel({
+    required this.title,
+    required this.description,
+    required this.date,
+    required this.link,
+  });
+
+  @override
+  List<Object?> get props => [title, description, date, link];
+
+  Map<String, dynamic> toJson() {
+    return {
+      'title': title,
+      'description': description,
+      'date': date.toIso8601String(),
+      'link': link,
+    };
+  }
+
+  static ContestModel fromJson(Map<String, dynamic> json) {
+    return ContestModel(
+      title: json['title'] as String,
+      description: json['description'] as String,
+      date: DateTime.parse(json['date'] as String),
+      link: json['link'] as String,
+    );
+  }
+}

--- a/a2sv_community_portal_mobile/lib/features/contest/data/repositories/contest_repository_impl.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/data/repositories/contest_repository_impl.dart
@@ -1,0 +1,44 @@
+import 'package:a2sv_community_portal_mobile/core/errors/exceptions.dart';
+import 'package:a2sv_community_portal_mobile/core/errors/failures.dart';
+import 'package:a2sv_community_portal_mobile/core/network/network_info.dart';
+import 'package:a2sv_community_portal_mobile/core/utils/constants.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/data/datasources/contest_remote_datasource.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/domain/entities/contest.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/domain/repository/contest_repository.dart';
+import 'package:dartz/dartz.dart';
+
+class ContestRepositoryImpl implements ContestRepository {
+  final ContestRemoteDataSource remoteDataSource;
+  final NetworkInfo networkInfo;
+
+  ContestRepositoryImpl({
+    required this.remoteDataSource,
+    required this.networkInfo,
+  });
+
+  @override
+  Future<Either<Failure, List<Contest>>> getContests() async {
+    if (await networkInfo.isConnected) {
+      try {
+        final contests = await remoteDataSource.getContests();
+        return Right(contests);
+      } on ServerException {
+        return const Left(ServerFailure(serverFaliure));
+      }
+    } else {
+      return Left(NoConnectionFailure(noConnectionError));
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<Contest>>> getPastContests() {
+    // TODO: implement getPastContests
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Either<Failure, List<Contest>>> getUpcomingContests() {
+    // TODO: implement getUpcomingContests
+    throw UnimplementedError();
+  }
+}

--- a/a2sv_community_portal_mobile/lib/features/contest/domain/repository/contest_repository.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/domain/repository/contest_repository.dart
@@ -3,6 +3,8 @@ import '../entities/contest.dart';
 import '../../../../core/errors/failures.dart';
 
 abstract class ContestRepository {
+
+  Future<Either<Failure,List<Contest>>> getContests();
   Future<Either<Failure,List<Contest>>> getUpcomingContests();
   Future<Either<Failure,List<Contest>>> getPastContests();
 }


### PR DESCRIPTION
Added domain layer to the contests feature. This includes the model, repository implementation, and datasource contract and implementation.