### PR TITLE
feat(mobile): Bloc consumption for contests feature

### DIFF
--- a/a2sv_community_portal_mobile/lib/core/network/network_info.dart
+++ b/a2sv_community_portal_mobile/lib/core/network/network_info.dart
@@ -7,7 +7,7 @@ abstract class NetworkInfo {
 class NetworkInfoImpl implements NetworkInfo {
   final InternetConnectionChecker connectionChecker;
 
-  NetworkInfoImpl(this.connectionChecker);
+  NetworkInfoImpl({required this.connectionChecker});
 
   @override
   Future<bool> get isConnected => connectionChecker.hasConnection;

--- a/a2sv_community_portal_mobile/lib/core/utils/colors.dart
+++ b/a2sv_community_portal_mobile/lib/core/utils/colors.dart
@@ -6,6 +6,7 @@ const Color blackColor = Colors.black;
 const Color blue = Colors.blue;
 const Color inputColor = Color(0xfff3f3f4);
 const Color grey = Color(0xff4A5568);
+const Color greyTextColor = Color.fromRGBO(168, 168, 168, 1);
 const Color primary = Color(0xFF3182CE);
 const Color boxShadowPrimary = Color.fromRGBO(0, 0, 0, 0.326);
 const Color boxShadowSecondary = Color.fromRGBO(0, 0, 0, 0.1);

--- a/a2sv_community_portal_mobile/lib/core/utils/format_date_and_time.dart
+++ b/a2sv_community_portal_mobile/lib/core/utils/format_date_and_time.dart
@@ -1,0 +1,9 @@
+import 'package:intl/intl.dart';
+
+Map<String, String> formatDateAndTime(DateTime date) {
+  final dateFormatter = DateFormat('MMMM d, y');
+  final formattedDate = dateFormatter.format(date);
+  final timeFormatter = DateFormat('HH:mm');
+  final formattedTime = timeFormatter.format(date);
+  return {'date': formattedDate, 'time': formattedTime};
+}

--- a/a2sv_community_portal_mobile/lib/features/contest/data/datasources/contest_remote_datasource.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/data/datasources/contest_remote_datasource.dart
@@ -7,29 +7,57 @@ import 'package:a2sv_community_portal_mobile/features/contest/domain/entities/co
 import 'package:http/http.dart' as http;
 
 abstract class ContestRemoteDataSource {
-  Future<List<Contest>> getContests();
+  Future<List<Contest>> getUpcomingContests();
+  Future<List<Contest>> getPastContests();
 }
 
 class ContestRemoteDataSourceImpl implements ContestRemoteDataSource {
   final http.Client client;
-  String uri = "https://api";
+  String uri = "https://a2sv-community-portal-api.onrender.com/api/Contests";
+  String token =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJlYWZlMzhkNS03NzU3LTQ4YjMtYTM5Yy1mZDI2YTBhYjkyZTQiLCJqdGkiOiI4MGM3ZWE0ZC1kYjFlLTQxZWMtOTk1Yi01Y2U3NGQwZmFkY2EiLCJlbWFpbCI6InRlbXBAZ21haWwuY29tIiwidW5pcXVlX25hbWUiOiJ0ZW1wQGdtYWlsLmNvbSIsImh0dHA6Ly9zY2hlbWFzLm1pY3Jvc29mdC5jb20vd3MvMjAwOC8wNi9pZGVudGl0eS9jbGFpbXMvcm9sZSI6IlN0dWRlbnQiLCJleHAiOjE2ODk5NjU0NjgsImlzcyI6IkEyU1YgQ29tbXVuaXR5IFBvcnRhbCIsImF1ZCI6IkEyU1YgQ29tbXVuaXR5IFBvcnRhbCJ9.b8rnzkNB080ICnvLnlsCtOJ_y3sa1AifUM-I0_5mRbw';
 
-  ContestRemoteDataSourceImpl(this.client);
+  ContestRemoteDataSourceImpl({required this.client});
+  @override
+  Future<List<Contest>> getPastContests() async {
+    final response = await client.get(
+      Uri.parse("$uri/recent"),
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $token'
+      },
+    );
+
+    if (response.statusCode == 200) {
+      final jsonContests = json.decode(response.body)["value"] as List<dynamic>;
+      final contests = jsonContests
+          .map((jsonContest) => ContestModel.fromJson(jsonContest))
+          .toList();
+
+      return Future.value(contests);
+    } else {
+      throw ServerException(serverFaliure);
+    }
+  }
 
   @override
-  Future<List<Contest>> getContests() async {
+  Future<List<Contest>> getUpcomingContests() async {
     final response = await client.get(
-      Uri.parse(uri),
-      headers: {'Content-Type': 'application/json'},
+      Uri.parse("$uri/upcoming"),
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $token'
+      },
     );
     if (response.statusCode == 200) {
-      final jsonContests = json.decode(response.body) as List<dynamic>;
-      return jsonContests
-          .map((jsonContest) => ContestModel.fromJson(jsonContest) as Contest)
+      final jsonContests = json.decode(response.body)["value"] as List<dynamic>;
+      final contests = jsonContests
+          .map((jsonContest) => ContestModel.fromJson(jsonContest))
           .toList();
+
+      return Future.value(contests);
     } else {
       throw ServerException(serverFaliure);
     }
   }
 }
-

--- a/a2sv_community_portal_mobile/lib/features/contest/data/model/contest.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/data/model/contest.dart
@@ -1,6 +1,7 @@
+import 'package:a2sv_community_portal_mobile/features/contest/domain/entities/contest.dart';
 import 'package:equatable/equatable.dart';
 
-class ContestModel extends Equatable {
+class ContestModel extends Contest {
   final String title;
   final String description;
   final DateTime date;
@@ -11,7 +12,7 @@ class ContestModel extends Equatable {
     required this.description,
     required this.date,
     required this.link,
-  });
+  }) : super(title: '', description: '', date: date, link: '');
 
   @override
   List<Object?> get props => [title, description, date, link];
@@ -20,17 +21,17 @@ class ContestModel extends Equatable {
     return {
       'title': title,
       'description': description,
-      'date': date.toIso8601String(),
+      'date': date,
       'link': link,
     };
   }
 
   static ContestModel fromJson(Map<String, dynamic> json) {
     return ContestModel(
-      title: json['title'] as String,
-      description: json['description'] as String,
+      title: json['title'] as String? ?? 'No title available',
+      description: json['description'] as String? ?? 'No description available',
       date: DateTime.parse(json['date'] as String),
-      link: json['link'] as String,
+      link: json['link'] as String? ?? 'No link available',
     );
   }
 }

--- a/a2sv_community_portal_mobile/lib/features/contest/data/repositories/contest_repository_impl.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/data/repositories/contest_repository_impl.dart
@@ -17,10 +17,10 @@ class ContestRepositoryImpl implements ContestRepository {
   });
 
   @override
-  Future<Either<Failure, List<Contest>>> getContests() async {
+  Future<Either<Failure, List<Contest>>> getPastContests() async {
     if (await networkInfo.isConnected) {
       try {
-        final contests = await remoteDataSource.getContests();
+        final contests = await remoteDataSource.getPastContests();
         return Right(contests);
       } on ServerException {
         return const Left(ServerFailure(serverFaliure));
@@ -31,12 +31,16 @@ class ContestRepositoryImpl implements ContestRepository {
   }
 
   @override
-  Future<Either<Failure, List<Contest>>> getPastContests() {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<Either<Failure, List<Contest>>> getUpcomingContests() {
-    throw UnimplementedError();
+  Future<Either<Failure, List<Contest>>> getUpcomingContests() async {
+    if (await networkInfo.isConnected) {
+      try {
+        final contests = await remoteDataSource.getUpcomingContests();
+        return Right(contests);
+      } on ServerException {
+        return const Left(ServerFailure(serverFaliure));
+      }
+    } else {
+      return const Left(NoConnectionFailure(noConnectionError));
+    }
   }
 }

--- a/a2sv_community_portal_mobile/lib/features/contest/domain/repository/contest_repository.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/domain/repository/contest_repository.dart
@@ -4,7 +4,6 @@ import '../../../../core/errors/failures.dart';
 
 abstract class ContestRepository {
 
-  Future<Either<Failure,List<Contest>>> getContests();
   Future<Either<Failure,List<Contest>>> getUpcomingContests();
   Future<Either<Failure,List<Contest>>> getPastContests();
 }

--- a/a2sv_community_portal_mobile/lib/features/contest/presentation/bloc/bloc/previous_contests_bloc.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/presentation/bloc/bloc/previous_contests_bloc.dart
@@ -1,0 +1,28 @@
+import 'package:a2sv_community_portal_mobile/features/contest/domain/entities/contest.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/domain/usecases/get_past_contests.dart';
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+
+part 'previous_contests_event.dart';
+part 'previous_contests_state.dart';
+
+class PreviousContestsBloc
+    extends Bloc<PreviousContestsEvent, PreviousContestsState> {
+  GetPastContests getPreviousContests;
+
+  PreviousContestsBloc({required this.getPreviousContests})
+      : super(PreviousContestsInitial()) {
+    on<PreviousContestsEvent>((event, emit) async {
+      if (event is FetchPreviousContests) {
+        emit(PreviousContestsLoading());
+
+        final response = await getPreviousContests();
+        response.fold(
+          (error) => emit(PreviousContestsError(message: error.toString())),
+          (previousContests) =>
+              emit(PreviousContestsLoaded(previousContests: previousContests)),
+        );
+      }
+    });
+  }
+}

--- a/a2sv_community_portal_mobile/lib/features/contest/presentation/bloc/bloc/previous_contests_bloc.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/presentation/bloc/bloc/previous_contests_bloc.dart
@@ -13,7 +13,7 @@ class PreviousContestsBloc
   PreviousContestsBloc({required this.getPreviousContests})
       : super(PreviousContestsInitial()) {
     on<PreviousContestsEvent>((event, emit) async {
-      if (event is FetchPreviousContests) {
+      if (event is FetchPreviousContestsEvent) {
         emit(PreviousContestsLoading());
 
         final response = await getPreviousContests();

--- a/a2sv_community_portal_mobile/lib/features/contest/presentation/bloc/bloc/previous_contests_event.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/presentation/bloc/bloc/previous_contests_event.dart
@@ -7,4 +7,4 @@ abstract class PreviousContestsEvent extends Equatable {
   List<Object> get props => [];
 }
 
-class FetchPreviousContests extends PreviousContestsEvent {}
+class FetchPreviousContestsEvent extends PreviousContestsEvent {}

--- a/a2sv_community_portal_mobile/lib/features/contest/presentation/bloc/bloc/previous_contests_event.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/presentation/bloc/bloc/previous_contests_event.dart
@@ -1,0 +1,10 @@
+part of 'previous_contests_bloc.dart';
+
+abstract class PreviousContestsEvent extends Equatable {
+  const PreviousContestsEvent();
+
+  @override
+  List<Object> get props => [];
+}
+
+class FetchPreviousContests extends PreviousContestsEvent {}

--- a/a2sv_community_portal_mobile/lib/features/contest/presentation/bloc/bloc/previous_contests_state.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/presentation/bloc/bloc/previous_contests_state.dart
@@ -1,0 +1,24 @@
+part of 'previous_contests_bloc.dart';
+
+abstract class PreviousContestsState extends Equatable {
+  const PreviousContestsState();
+
+  @override
+  List<Object> get props => [];
+}
+
+class PreviousContestsInitial extends PreviousContestsState {}
+
+class PreviousContestsLoading extends PreviousContestsState {}
+
+class PreviousContestsLoaded extends PreviousContestsState {
+  final List<Contest> previousContests;
+
+  const PreviousContestsLoaded({required this.previousContests});
+}
+
+class PreviousContestsError extends PreviousContestsState {
+  final String message;
+
+  const PreviousContestsError({required this.message});
+}

--- a/a2sv_community_portal_mobile/lib/features/contest/presentation/bloc/bloc/upcoming_contests_bloc.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/presentation/bloc/bloc/upcoming_contests_bloc.dart
@@ -12,7 +12,7 @@ class UpcomingContestsBloc
   UpcomingContestsBloc({required this.getUpcomingContests})
       : super(UpcomingContestsInitial()) {
     on<UpcomingContestsEvent>((event, emit) async {
-      if (event is FetchUpcomingContests) {
+      if (event is FetchUpcomingContestsEvent) {
         emit(UpcomingContestsLoading());
 
         final response = await getUpcomingContests();

--- a/a2sv_community_portal_mobile/lib/features/contest/presentation/bloc/bloc/upcoming_contests_bloc.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/presentation/bloc/bloc/upcoming_contests_bloc.dart
@@ -1,0 +1,27 @@
+import 'package:a2sv_community_portal_mobile/features/contest/domain/entities/contest.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/domain/usecases/get_upcoming_contests.dart';
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+
+part 'upcoming_contests_event.dart';
+part 'upcoming_contests_state.dart';
+
+class UpcomingContestsBloc
+    extends Bloc<UpcomingContestsEvent, UpcomingContestsState> {
+  GetUpcomingContests getUpcomingContests;
+  UpcomingContestsBloc({required this.getUpcomingContests})
+      : super(UpcomingContestsInitial()) {
+    on<UpcomingContestsEvent>((event, emit) async {
+      if (event is FetchUpcomingContests) {
+        emit(UpcomingContestsLoading());
+
+        final response = await getUpcomingContests();
+        response.fold(
+          (error) => emit(UpcomingContestsError(message: error.toString())),
+          (upcomingContests) =>
+              emit(UpcomingContestsLoaded(upcomingContests: upcomingContests)),
+        );
+      }
+    });
+  }
+}

--- a/a2sv_community_portal_mobile/lib/features/contest/presentation/bloc/bloc/upcoming_contests_event.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/presentation/bloc/bloc/upcoming_contests_event.dart
@@ -1,0 +1,10 @@
+part of 'upcoming_contests_bloc.dart';
+
+abstract class UpcomingContestsEvent extends Equatable {
+  const UpcomingContestsEvent();
+
+  @override
+  List<Object> get props => [];
+}
+
+class FetchUpcomingContests extends UpcomingContestsEvent {}

--- a/a2sv_community_portal_mobile/lib/features/contest/presentation/bloc/bloc/upcoming_contests_event.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/presentation/bloc/bloc/upcoming_contests_event.dart
@@ -7,4 +7,4 @@ abstract class UpcomingContestsEvent extends Equatable {
   List<Object> get props => [];
 }
 
-class FetchUpcomingContests extends UpcomingContestsEvent {}
+class FetchUpcomingContestsEvent extends UpcomingContestsEvent {}

--- a/a2sv_community_portal_mobile/lib/features/contest/presentation/bloc/bloc/upcoming_contests_state.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/presentation/bloc/bloc/upcoming_contests_state.dart
@@ -1,0 +1,24 @@
+part of 'upcoming_contests_bloc.dart';
+
+abstract class UpcomingContestsState extends Equatable {
+  const UpcomingContestsState();
+
+  @override
+  List<Object> get props => [];
+}
+
+class UpcomingContestsInitial extends UpcomingContestsState {}
+
+class UpcomingContestsLoading extends UpcomingContestsState {}
+
+class UpcomingContestsLoaded extends UpcomingContestsState {
+  final List<Contest> upcomingContests;
+
+  const UpcomingContestsLoaded({required this.upcomingContests});
+}
+
+class UpcomingContestsError extends UpcomingContestsState {
+  final String message;
+
+  const UpcomingContestsError({required this.message});
+}

--- a/a2sv_community_portal_mobile/lib/features/contest/presentation/pages/upcoming_and_recent_contest_page.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/presentation/pages/upcoming_and_recent_contest_page.dart
@@ -1,80 +1,103 @@
-import 'package:a2sv_community_portal_mobile/core/utils/widgets/bottom_bar.dart';
-import 'package:a2sv_community_portal_mobile/core/utils/widgets/upper_bar.dart';
-import 'package:a2sv_community_portal_mobile/features/contest/presentation/widgets/list_tile.dart';
+import 'package:a2sv_community_portal_mobile/core/network/network_info.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/data/datasources/contest_remote_datasource.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/data/repositories/contest_repository_impl.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/domain/usecases/get_past_contests.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/domain/usecases/get_upcoming_contests.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/presentation/bloc/bloc/previous_contests_bloc.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/presentation/bloc/bloc/upcoming_contests_bloc.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/presentation/widgets/previous_contests.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/presentation/widgets/upcoming_contests.dart';
 import 'package:flutter/material.dart';
+import 'package:internet_connection_checker/internet_connection_checker.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../widgets/upper_bar.dart';
+import 'package:http/http.dart' as http;
 
 class ContestPage extends StatelessWidget {
-  final List<Map<String, String>> _contests = [
-    {
-      "title": "OnBoarding Contest #2 Div-1 ",
-      "date": "June 18,2023",
-      "time": "9:00pm EAT"
-    },
-    {
-      "title": "OnBoarding Contest #2 Div-1 ",
-      "date": "June 18,2023",
-      "time": "9:00pm EAT"
-    },
-    {
-      "title": "OnBoarding Contest #2 Div-1 ",
-      "date": "June 18,2023",
-      "time": "9:00pm EAT"
-    },
-  ];
+  final http.Client httpClient = http.Client();
+  final InternetConnectionChecker internetConnectionChecker =
+      InternetConnectionChecker();
 
   ContestPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: const UpperBar(),
-      body: ListView(
-        children: [
-          const SizedBox(height: 26),
-          Container(
-              padding: const EdgeInsets.only(left: 16.0, right: 16.0),
-              child: const Text('Upcoming Contests',
-                  style: TextStyle(
-                      fontSize: 24,
-                      fontWeight: FontWeight.w600,
-                      color: Color.fromRGBO(0, 0, 0, 0.92)))),
-          const SizedBox(height: 26),
-          Column(
-            children: <Widget>[
-              for (var c in _contests)
-                Container(
-                    margin: const EdgeInsets.only(bottom: 10),
-                    padding: const EdgeInsets.only(left: 16.0, right: 16.0),
-                    child: CustomListTile(
-                        header: c["title"]!,
-                        date: c["date"]!,
-                        time: c["time"]!))
+    final NetworkInfo networkInfo =
+        NetworkInfoImpl(connectionChecker: internetConnectionChecker);
+
+    final ContestRemoteDataSource contestRemoteDataSource =
+        ContestRemoteDataSourceImpl(client: httpClient);
+
+    final ContestRepositoryImpl contestRepository = ContestRepositoryImpl(
+        networkInfo: networkInfo, remoteDataSource: contestRemoteDataSource);
+
+    final GetPastContests getPreviousContests =
+        GetPastContests(repository: contestRepository);
+    final GetUpcomingContests getUpcomingContests =
+        GetUpcomingContests(repository: contestRepository);
+
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<UpcomingContestsBloc>(
+            create: (context) =>
+                UpcomingContestsBloc(getUpcomingContests: getUpcomingContests)
+                  ..add(FetchUpcomingContests())),
+
+        BlocProvider<PreviousContestsBloc>(
+          create: (context) =>
+              PreviousContestsBloc(getPreviousContests: getPreviousContests)
+                ..add(FetchPreviousContests()),
+        ),
+
+        // Add more bloc providers for other blocs if needed
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: ThemeData(
+            scaffoldBackgroundColor: const Color.fromRGBO(255, 255, 255, 1)),
+        home: Scaffold(
+          body: ListView(
+            children: [
+              UpperBar(),
+              const SizedBox(height: 26),
+              Container(
+                  padding: const EdgeInsets.only(left: 16.0, right: 16.0),
+                  child: const Text('Upcoming Contests',
+                      style: TextStyle(
+                          fontSize: 24,
+                          fontWeight: FontWeight.w600,
+                          color: Color.fromRGBO(0, 0, 0, 0.92)))),
+              const SizedBox(height: 26),
+              UpcommingContests(),
+              Container(
+                  padding: const EdgeInsets.only(
+                      left: 16.0, right: 16.0, top: 16, bottom: 16),
+                  child: const Text('Recent Contests',
+                      style: TextStyle(
+                          fontSize: 24,
+                          fontWeight: FontWeight.w600,
+                          color: Color.fromRGBO(0, 0, 0, 0.92)))),
+              const PreviousContests(),
+              const SizedBox(
+                height: 50,
+              )
             ],
           ),
-          Container(
-              padding: const EdgeInsets.only(
-                  left: 16.0, right: 16.0, top: 16, bottom: 16),
-              child: const Text('Recent Contests',
-                  style: TextStyle(
-                      fontSize: 24,
-                      fontWeight: FontWeight.w600,
-                      color: Color.fromRGBO(0, 0, 0, 0.92)))),
-          Column(
-            children: <Widget>[
-              for (var c in _contests)
-                Container(
-                    margin: const EdgeInsets.only(bottom: 10),
-                    padding: const EdgeInsets.only(left: 16.0, right: 16.0),
-                    child: CustomListTile(
-                        header: c["title"]!,
-                        date: c["date"]!,
-                        time: c["time"]!))
-            ],
-          ),
-          const SizedBox(
-            height: 50,
-          )
-        ],
+          bottomNavigationBar: BottomNavigationBar(items: const [
+            BottomNavigationBarItem(
+              icon: Icon(Icons.home_max_outlined),
+              label: 'Home',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.code),
+              label: 'Contest',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.person),
+              label: 'Profile',
+            ),
+          ]),
+        ),
       ),
       bottomNavigationBar: const MainBottomNavigationBar(),
     );

--- a/a2sv_community_portal_mobile/lib/features/contest/presentation/pages/upcoming_and_recent_contest_page.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/presentation/pages/upcoming_and_recent_contest_page.dart
@@ -1,15 +1,8 @@
-import 'package:a2sv_community_portal_mobile/core/network/network_info.dart';
-import 'package:a2sv_community_portal_mobile/features/contest/data/datasources/contest_remote_datasource.dart';
-import 'package:a2sv_community_portal_mobile/features/contest/data/repositories/contest_repository_impl.dart';
-import 'package:a2sv_community_portal_mobile/features/contest/domain/usecases/get_past_contests.dart';
-import 'package:a2sv_community_portal_mobile/features/contest/domain/usecases/get_upcoming_contests.dart';
-import 'package:a2sv_community_portal_mobile/features/contest/presentation/bloc/bloc/previous_contests_bloc.dart';
-import 'package:a2sv_community_portal_mobile/features/contest/presentation/bloc/bloc/upcoming_contests_bloc.dart';
+import 'package:a2sv_community_portal_mobile/core/utils/widgets/bottom_bar.dart';
 import 'package:a2sv_community_portal_mobile/features/contest/presentation/widgets/previous_contests.dart';
 import 'package:a2sv_community_portal_mobile/features/contest/presentation/widgets/upcoming_contests.dart';
 import 'package:flutter/material.dart';
 import 'package:internet_connection_checker/internet_connection_checker.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import '../widgets/upper_bar.dart';
 import 'package:http/http.dart' as http;
 
@@ -22,82 +15,33 @@ class ContestPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final NetworkInfo networkInfo =
-        NetworkInfoImpl(connectionChecker: internetConnectionChecker);
-
-    final ContestRemoteDataSource contestRemoteDataSource =
-        ContestRemoteDataSourceImpl(client: httpClient);
-
-    final ContestRepositoryImpl contestRepository = ContestRepositoryImpl(
-        networkInfo: networkInfo, remoteDataSource: contestRemoteDataSource);
-
-    final GetPastContests getPreviousContests =
-        GetPastContests(repository: contestRepository);
-    final GetUpcomingContests getUpcomingContests =
-        GetUpcomingContests(repository: contestRepository);
-
-    return MultiBlocProvider(
-      providers: [
-        BlocProvider<UpcomingContestsBloc>(
-            create: (context) =>
-                UpcomingContestsBloc(getUpcomingContests: getUpcomingContests)
-                  ..add(FetchUpcomingContests())),
-
-        BlocProvider<PreviousContestsBloc>(
-          create: (context) =>
-              PreviousContestsBloc(getPreviousContests: getPreviousContests)
-                ..add(FetchPreviousContests()),
-        ),
-
-        // Add more bloc providers for other blocs if needed
-      ],
-      child: MaterialApp(
-        debugShowCheckedModeBanner: false,
-        theme: ThemeData(
-            scaffoldBackgroundColor: const Color.fromRGBO(255, 255, 255, 1)),
-        home: Scaffold(
-          body: ListView(
-            children: [
-              UpperBar(),
-              const SizedBox(height: 26),
-              Container(
-                  padding: const EdgeInsets.only(left: 16.0, right: 16.0),
-                  child: const Text('Upcoming Contests',
-                      style: TextStyle(
-                          fontSize: 24,
-                          fontWeight: FontWeight.w600,
-                          color: Color.fromRGBO(0, 0, 0, 0.92)))),
-              const SizedBox(height: 26),
-              UpcommingContests(),
-              Container(
-                  padding: const EdgeInsets.only(
-                      left: 16.0, right: 16.0, top: 16, bottom: 16),
-                  child: const Text('Recent Contests',
-                      style: TextStyle(
-                          fontSize: 24,
-                          fontWeight: FontWeight.w600,
-                          color: Color.fromRGBO(0, 0, 0, 0.92)))),
-              const PreviousContests(),
-              const SizedBox(
-                height: 50,
-              )
-            ],
-          ),
-          bottomNavigationBar: BottomNavigationBar(items: const [
-            BottomNavigationBarItem(
-              icon: Icon(Icons.home_max_outlined),
-              label: 'Home',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.code),
-              label: 'Contest',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.person),
-              label: 'Profile',
-            ),
-          ]),
-        ),
+    return Scaffold(
+      body: ListView(
+        children: [
+          UpperBar(),
+          const SizedBox(height: 26),
+          Container(
+              padding: const EdgeInsets.only(left: 16.0, right: 16.0),
+              child: const Text('Upcoming Contests',
+                  style: TextStyle(
+                      fontSize: 24,
+                      fontWeight: FontWeight.w600,
+                      color: Color.fromRGBO(0, 0, 0, 0.92)))),
+          const SizedBox(height: 26),
+          UpcommingContests(),
+          Container(
+              padding: const EdgeInsets.only(
+                  left: 16.0, right: 16.0, top: 16, bottom: 16),
+              child: const Text('Recent Contests',
+                  style: TextStyle(
+                      fontSize: 24,
+                      fontWeight: FontWeight.w600,
+                      color: Color.fromRGBO(0, 0, 0, 0.92)))),
+          const PreviousContests(),
+          const SizedBox(
+            height: 50,
+          )
+        ],
       ),
       bottomNavigationBar: const MainBottomNavigationBar(),
     );

--- a/a2sv_community_portal_mobile/lib/features/contest/presentation/widgets/list_tile.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/presentation/widgets/list_tile.dart
@@ -6,7 +6,7 @@ class CustomListTile extends StatelessWidget {
   final String time;
 
   const CustomListTile({
-    super.key, 
+    super.key,
     required this.header,
     required this.date,
     required this.time,
@@ -16,11 +16,13 @@ class CustomListTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       padding: const EdgeInsets.all(7),
-      decoration:  BoxDecoration(
-        border: const Border(top: BorderSide(color: Color.fromRGBO(0, 0, 0, 0.08)),bottom: BorderSide(color: Color.fromRGBO(0, 0, 0, 0.08)),left: BorderSide(color: Color.fromRGBO(0, 0, 0, 0.08)),right: BorderSide(color: Color.fromRGBO(0, 0, 0, 0.08))),
+      decoration: BoxDecoration(
+        border: const Border(
+            top: BorderSide(color: Color.fromRGBO(0, 0, 0, 0.08)),
+            bottom: BorderSide(color: Color.fromRGBO(0, 0, 0, 0.08)),
+            left: BorderSide(color: Color.fromRGBO(0, 0, 0, 0.08)),
+            right: BorderSide(color: Color.fromRGBO(0, 0, 0, 0.08))),
         borderRadius: BorderRadius.circular(8.0),
-        
-        
       ),
       child: ListTile(
         title: Text(
@@ -32,19 +34,16 @@ class CustomListTile extends StatelessWidget {
           ),
         ),
         subtitle: Container(
-          padding: const EdgeInsets.only(top: 5 ,bottom:0 ),
+          padding: const EdgeInsets.only(top: 5, bottom: 0),
           child: Text(
-                '$date  $time',
-                style: const TextStyle(
-                  color: Color.fromRGBO(0, 0, 0, 0.24),
-                  fontWeight: FontWeight.w500,
-                  fontSize: 12,
-            
-            
-                ),
-              ),
+            '$date  $time',
+            style: const TextStyle(
+              color: Color.fromRGBO(0, 0, 0, 0.24),
+              fontWeight: FontWeight.w500,
+              fontSize: 12,
+            ),
+          ),
         ),
-        
       ),
     );
   }

--- a/a2sv_community_portal_mobile/lib/features/contest/presentation/widgets/previous_contests.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/presentation/widgets/previous_contests.dart
@@ -1,3 +1,4 @@
+import 'package:a2sv_community_portal_mobile/core/utils/colors.dart';
 import 'package:a2sv_community_portal_mobile/core/utils/format_date_and_time.dart';
 import 'package:a2sv_community_portal_mobile/features/contest/presentation/bloc/bloc/previous_contests_bloc.dart';
 import 'package:a2sv_community_portal_mobile/features/contest/presentation/widgets/list_tile.dart';
@@ -21,11 +22,11 @@ class PreviousContests extends StatelessWidget {
         } else if (state is PreviousContestsLoaded) {
           if (state.previousContests.isEmpty) {
             return Container(
-              padding: const EdgeInsets.only(left: 16.0, right: 16.0),
+              padding: const EdgeInsets.only(top: 50),
               child: const Center(
                 child: Text(
                   "No Recent Contests",
-                  style: TextStyle(fontSize: 20, fontWeight: FontWeight.w500),
+                  style: TextStyle(fontSize: 20, fontWeight: FontWeight.w500, color: greyTextColor),
                 ),
               ),
             );

--- a/a2sv_community_portal_mobile/lib/features/contest/presentation/widgets/previous_contests.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/presentation/widgets/previous_contests.dart
@@ -1,0 +1,56 @@
+import 'package:a2sv_community_portal_mobile/core/utils/format_date_and_time.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/presentation/bloc/bloc/previous_contests_bloc.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/presentation/widgets/list_tile.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class PreviousContests extends StatelessWidget {
+  const PreviousContests({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<PreviousContestsBloc, PreviousContestsState>(
+      builder: (context, state) {
+        if (state is PreviousContestsLoading) {
+          return Container(
+            alignment: Alignment.center,
+            width: 50,
+            height: 50,
+            child: const CircularProgressIndicator(),
+          );
+        } else if (state is PreviousContestsLoaded) {
+          if (state.previousContests.isEmpty) {
+            return Container(
+              padding: const EdgeInsets.only(left: 16.0, right: 16.0),
+              child: const Center(
+                child: Text(
+                  "No Recent Contests",
+                  style: TextStyle(fontSize: 20, fontWeight: FontWeight.w500),
+                ),
+              ),
+            );
+          } else {
+            return Column(
+              children: <Widget>[
+                for (var contest in state.previousContests)
+                  Container(
+                    margin: const EdgeInsets.only(bottom: 10),
+                    padding: const EdgeInsets.only(left: 16.0, right: 16.0),
+                    child: CustomListTile(
+                      header: contest.title,
+                      date: formatDateAndTime(contest.date)['date'] ?? "",
+                      time: formatDateAndTime(contest.date)['time'] ?? "",
+                    ),
+                  )
+              ],
+            );
+          }
+        } else if (state is PreviousContestsError) {
+          return Text(state.message);
+        } else {
+          return Container();
+        }
+      },
+    );
+  }
+}

--- a/a2sv_community_portal_mobile/lib/features/contest/presentation/widgets/upcoming_contests.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/presentation/widgets/upcoming_contests.dart
@@ -1,3 +1,4 @@
+import 'package:a2sv_community_portal_mobile/core/utils/colors.dart';
 import 'package:a2sv_community_portal_mobile/core/utils/format_date_and_time.dart';
 import 'package:a2sv_community_portal_mobile/features/contest/presentation/bloc/bloc/upcoming_contests_bloc.dart';
 import 'package:a2sv_community_portal_mobile/features/contest/presentation/widgets/list_tile.dart';
@@ -17,23 +18,38 @@ class UpcommingContests extends StatelessWidget {
             alignment: Alignment.center,
             width: 50,
             height: 50,
-            child:  const CircularProgressIndicator(),
+            child: const CircularProgressIndicator(),
           );
         } else if (state is UpcomingContestsLoaded) {
-          return Column(
-            children: <Widget>[
-              for (var contest in state.upcomingContests)
-                Container(
-                  margin: const EdgeInsets.only(bottom: 10),
-                  padding: const EdgeInsets.only(left: 16.0, right: 16.0),
-                  child: CustomListTile(
-                    header: contest.title,
-                    date: formatDateAndTime(contest.date)['date'] ?? "",
-                    time: formatDateAndTime(contest.date)['time'] ?? "",
-                  ),
-                )
-            ],
-          );
+          if (state.upcomingContests.isEmpty) {
+            return Container(
+              padding: const EdgeInsets.only(top: 50),
+              child: const Center(
+                child: Text(
+                  "No Recent Contests",
+                  style: TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.w500,
+                      color: greyTextColor),
+                ),
+              ),
+            );
+          } else {
+            return Column(
+              children: <Widget>[
+                for (var contest in state.upcomingContests)
+                  Container(
+                    margin: const EdgeInsets.only(bottom: 10),
+                    padding: const EdgeInsets.only(left: 16.0, right: 16.0),
+                    child: CustomListTile(
+                      header: contest.title,
+                      date: formatDateAndTime(contest.date)['date'] ?? "",
+                      time: formatDateAndTime(contest.date)['time'] ?? "",
+                    ),
+                  )
+              ],
+            );
+          }
         } else if (state is UpcomingContestsError) {
           return Text(state.message);
         } else {

--- a/a2sv_community_portal_mobile/lib/features/contest/presentation/widgets/upcoming_contests.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/presentation/widgets/upcoming_contests.dart
@@ -1,0 +1,45 @@
+import 'package:a2sv_community_portal_mobile/core/utils/format_date_and_time.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/presentation/bloc/bloc/upcoming_contests_bloc.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/presentation/widgets/list_tile.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class UpcommingContests extends StatelessWidget {
+  UpcommingContests({super.key});
+  final contests = [];
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<UpcomingContestsBloc, UpcomingContestsState>(
+      builder: (context, state) {
+        if (state is UpcomingContestsLoading) {
+          return Container(
+            alignment: Alignment.center,
+            width: 50,
+            height: 50,
+            child:  const CircularProgressIndicator(),
+          );
+        } else if (state is UpcomingContestsLoaded) {
+          return Column(
+            children: <Widget>[
+              for (var contest in state.upcomingContests)
+                Container(
+                  margin: const EdgeInsets.only(bottom: 10),
+                  padding: const EdgeInsets.only(left: 16.0, right: 16.0),
+                  child: CustomListTile(
+                    header: contest.title,
+                    date: formatDateAndTime(contest.date)['date'] ?? "",
+                    time: formatDateAndTime(contest.date)['time'] ?? "",
+                  ),
+                )
+            ],
+          );
+        } else if (state is UpcomingContestsError) {
+          return Text(state.message);
+        } else {
+          return Container();
+        }
+      },
+    );
+  }
+}

--- a/a2sv_community_portal_mobile/lib/features/contest/presentation/widgets/upper_bar.dart
+++ b/a2sv_community_portal_mobile/lib/features/contest/presentation/widgets/upper_bar.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+
+class UpperBar extends StatelessWidget {
+  const UpperBar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.only(top: 16.0, left: 16.0, right: 16.0),
+      child: Row(
+        children: [
+           const Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Welcome',
+                  style: TextStyle(
+                      fontSize: 14, color: Color.fromRGBO(168, 168, 168, 1)),
+                ),
+                SizedBox(height: 4.0), // Adds spacing between the texts
+                Text(
+                  'Joe Doe',
+                  style: TextStyle(
+                      fontSize: 20,
+                      color: Color.fromRGBO(0, 0, 0, 1),
+                      fontWeight: FontWeight.w600),
+                ),
+              ],
+            ),
+          ),
+          Align(
+            alignment: Alignment.topRight,
+            child: Stack(
+              children: [
+                Container(
+                  decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(10),
+                      color: const Color.fromRGBO(235, 248, 255, 1)),
+                  padding: const EdgeInsets.all(5),
+                  height: 46,
+                  width: 46,
+                  margin: const EdgeInsets.only(top: 5),
+                  child: const Icon(
+                    Icons.notifications,
+                    color: Color.fromRGBO(26, 54, 93, 1),
+                    size: 24,
+                  ),
+                ),
+                Container(
+                  width: 11.0,
+                  height: 11.0,
+                  margin: const EdgeInsets.only(left: 33, top: 2),
+                  decoration: const BoxDecoration(
+                    color: Color.fromRGBO(49, 130, 206, 1),
+                    shape: BoxShape.circle,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/a2sv_community_portal_mobile/lib/injections/injection_container.dart
+++ b/a2sv_community_portal_mobile/lib/injections/injection_container.dart
@@ -1,32 +1,55 @@
+import 'package:a2sv_community_portal_mobile/core/network/network_info.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/data/datasources/contest_remote_datasource.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/data/repositories/contest_repository_impl.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/domain/repository/contest_repository.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/domain/usecases/get_past_contests.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/domain/usecases/get_upcoming_contests.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/presentation/bloc/bloc/previous_contests_bloc.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/presentation/bloc/bloc/upcoming_contests_bloc.dart';
 import 'package:get_it/get_it.dart';
 import 'package:internet_connection_checker/internet_connection_checker.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:http/http.dart' as http;
 
-
 final sl = GetIt.instance;
 
 Future<void> init() async {
-  //! Features - UserProfile
-
-
-  //! Features - Contest
-
-
-  //! Features - Application
-
-
-  //! Features - Notification 
-
-
-  //! Features - Authentication
-
   //! Core
   final sharedPreferences = SharedPreferences.getInstance();
   sl.registerLazySingletonAsync(() => sharedPreferences);
   await GetIt.instance.isReady<SharedPreferences>();
   sl.registerLazySingleton(() => http.Client());
-  sl.registerLazySingleton(() => InternetConnectionChecker());
+  sl.registerLazySingleton<InternetConnectionChecker>(
+    () => InternetConnectionChecker(),
+  );
+  sl.registerFactory<NetworkInfo>(
+      () => NetworkInfoImpl(connectionChecker: sl()));
+
+  //! Features - UserProfile
+
+  //! Features - Contest
+  //usecase
+  sl.registerLazySingleton(() => GetPastContests(repository: sl()));
+  sl.registerLazySingleton(() => GetUpcomingContests(repository: sl()));
+  // repository
+  sl.registerLazySingleton<ContestRepository>(() => ContestRepositoryImpl(
+        networkInfo: sl(),
+        remoteDataSource: sl(),
+      ));
+
+  // datasource
+  sl.registerLazySingleton<ContestRemoteDataSource>(
+      () => ContestRemoteDataSourceImpl(client: sl()));
+
+  // bloc
+  sl.registerFactory(() => UpcomingContestsBloc(getUpcomingContests: sl()));
+  sl.registerFactory(() => PreviousContestsBloc(getPreviousContests: sl()));
+
+  //! Features - Application
+
+  //! Features - Notification
+
+  //! Features - Authentication
 
   //! External
 }

--- a/a2sv_community_portal_mobile/lib/main.dart
+++ b/a2sv_community_portal_mobile/lib/main.dart
@@ -1,19 +1,38 @@
-import 'package:a2sv_community_portal_mobile/features/application_page/presentation/screen/home.dart';
-import 'package:flutter/material.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/presentation/pages/upcoming_and_recent_contest_page.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/presentation/bloc/bloc/previous_contests_bloc.dart';
+import 'package:a2sv_community_portal_mobile/features/contest/presentation/bloc/bloc/upcoming_contests_bloc.dart';
 
-void main() {
+import 'package:a2sv_community_portal_mobile/injections/injection_container.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await init();
   runApp(const MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  const MyApp({Key? key}) : super(key: key);
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      debugShowCheckedModeBanner: false,
-      home: Home(),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<UpcomingContestsBloc>(
+          create: (_) =>
+              sl<UpcomingContestsBloc>()..add(FetchUpcomingContestsEvent()),
+        ),
+        BlocProvider<PreviousContestsBloc>(
+          create: (_) =>
+              sl<PreviousContestsBloc>()..add(FetchPreviousContestsEvent()),
+        ),
+        // Add more bloc providers for other blocs if needed
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        home: ContestPage(),
+      ),
     );
   }
 }

--- a/a2sv_community_portal_mobile/pubspec.yaml
+++ b/a2sv_community_portal_mobile/pubspec.yaml
@@ -43,8 +43,10 @@ dependencies:
   internet_connection_checker: ^1.0.0+1
   google_fonts: ^4.0.4
   bloc: ^8.1.2
+  flutter_bloc: ^8.1.3 
   percent_indicator: ^4.2.3
   get_it: ^7.6.0
+  intl: ^0.18.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pull request adds contest feature bloc consumption to the app. The following changes were made:

- Created ContestEvent and ContestState classes for the contest feature.
- Created UpcomingContestBloc and PreviousContestBloc to handle the business logic for fetching upcoming and previous contests respectively.
- Created GetUpcomingContests and GetPastContests abstractions and their implementations to fetch the upcoming and previous contests from the API.
- Consumed the blocs in the ContestPage widget to display the upcoming and previous contests.
- Created dependency injection using GetIt to provide the necessary dependencies to the blocs.